### PR TITLE
Add syntax-sugar mapping

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,35 @@
+#
+# NOTE:
+# To fix `trailing_whitespace` error,
+# go to Xcode Preferences -> Text Editing -> turn on both "Automatically trim trailing whitespace" and "Including whitespace-only lines".
+#
+
+disabled_rules:
+  - line_length
+  - function_body_length
+  - type_body_length
+  - file_length
+  - cyclomatic_complexity
+
+  - force_cast
+
+  - opening_brace         # prefer Allman-Style
+  - closing_brace         # allow `}\n)`
+  - statement_position    # allow `if {}\nelse {}`
+  - type_name             # allow "_" prefix name
+  - variable_name         # allow "_" prefix name
+  - todo
+  - valid_docs
+
+opt_in_rules:
+  - empty_count  # local variable name `count` is frequently used
+
+included:
+ - Sources
+ - Tests
+
+excluded:
+  - Carthage
+  - Packages
+
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)

--- a/ReactiveAutomaton.xcodeproj/project.pbxproj
+++ b/ReactiveAutomaton.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		1FAEBD081CDCF04E0046EA72 /* Reply.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAEBD071CDCF04E0046EA72 /* Reply.swift */; };
 		1FAEBD0A1CDCF0990046EA72 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FAEBD091CDCF0990046EA72 /* Result.framework */; };
 		1FAEBD0C1CDCF0A10046EA72 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FAEBD0B1CDCF0A10046EA72 /* ReactiveCocoa.framework */; };
+		48B2D1141CED890D0095F175 /* Mapping+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B2D1131CED890D0095F175 /* Mapping+Helper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -260,6 +261,7 @@
 		1FAEBD071CDCF04E0046EA72 /* Reply.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reply.swift; sourceTree = "<group>"; };
 		1FAEBD091CDCF0990046EA72 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FAEBD0B1CDCF0A10046EA72 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		48B2D1131CED890D0095F175 /* Mapping+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Mapping+Helper.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -428,6 +430,7 @@
 				1FAEBD021CDCEF940046EA72 /* ReactiveAutomaton.h */,
 				1FAEBD051CDCEFD50046EA72 /* Automaton.swift */,
 				1FAEBD071CDCF04E0046EA72 /* Reply.swift */,
+				48B2D1131CED890D0095F175 /* Mapping+Helper.swift */,
 				1F24E04C1CDD0F610008028E /* Internals */,
 				1FAEBD011CDCEF940046EA72 /* Info.plist */,
 			);
@@ -479,6 +482,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1FAEBCFD1CDCEF520046EA72 /* Build configuration list for PBXNativeTarget "ReactiveAutomaton" */;
 			buildPhases = (
+				48B2D1341CEDAC5D0095F175 /* SwiftLint */,
 				1FAEBCF01CDCEF510046EA72 /* Sources */,
 				1FAEBCF11CDCEF510046EA72 /* Frameworks */,
 				1FAEBCF21CDCEF510046EA72 /* Headers */,
@@ -776,6 +780,23 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		48B2D1341CEDAC5D0095F175 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		1F24EB0D1CDD19240008028E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -791,6 +812,7 @@
 			files = (
 				1FAEBD081CDCF04E0046EA72 /* Reply.swift in Sources */,
 				1F24E04B1CDD0D760008028E /* ReactiveCocoa+SampleFrom.swift in Sources */,
+				48B2D1141CED890D0095F175 /* Mapping+Helper.swift in Sources */,
 				1FAEBD061CDCEFD50046EA72 /* Automaton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Mapping+Helper.swift
+++ b/Sources/Mapping+Helper.swift
@@ -1,0 +1,74 @@
+//
+//  Mapping+Helper.swift
+//  ReactiveAutomaton
+//
+//  Created by Yasuhiro Inami on 2016-05-19.
+//  Copyright © 2016 Yasuhiro Inami. All rights reserved.
+//
+
+/// "From-" and "to-" states represented as `.State1 => .State2` or `anyState => .State3`.
+public struct Transition<State>
+{
+    public let fromState: State -> Bool
+    public let toState: State
+}
+
+// MARK: - Custom Operators
+
+infix operator => { associativity left precedence 150 } // higher than `|` (precedence 140)
+
+public func => <State>(left: State -> Bool, right: State) -> Transition<State>
+{
+    return Transition(fromState: left, toState: right)
+}
+
+public func => <State: Equatable>(left: State, right: State) -> Transition<State>
+{
+    return { $0 == left } => right
+}
+
+//infix operator | { associativity left precedence 140 }   // Comment-Out: already built-in
+
+public func | <State: StateType, Input: InputType>(inputFunc: Input -> Bool, transition: Transition<State>) -> Automaton<State, Input>.Mapping
+{
+    return { state, input in
+        if inputFunc(input) && transition.fromState(state) {
+            return transition.toState
+        }
+        else {
+            return nil
+        }
+    }
+}
+
+public func | <State: StateType, Input: protocol<InputType, Equatable>>(input: Input, transition: Transition<State>) -> Automaton<State, Input>.Mapping
+{
+    return { $0 == input } | transition
+}
+
+// MARK: Functions
+
+/// Helper for "any state" mapping, e.g. `let mapping = .Input0 | anyState => .State1`.
+public func anyState<State: StateType>(_: State) -> Bool
+{
+    return true
+}
+
+/// Helper for "any input" mapping, e.g. `let mapping = anyInput | .State1 => .State2`.
+public func anyInput<Input: InputType>(_: Input) -> Bool
+{
+    return true
+}
+
+/// Concatenates multiple `Automaton.Mapping`s to one (preceding mapping has higher priority).
+public func concat<State: StateType, Input: InputType, Mappings: SequenceType where Mappings.Generator.Element == Automaton<State, Input>.Mapping>(mappings: Mappings) -> Automaton<State, Input>.Mapping
+{
+    return { state, input in
+        for mapping in mappings {
+            if let toState = mapping(state, input) {
+                return toState
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Supported syntax-sugar mapping using `|` and `=>` custom operators.
### Example

``` swift
func mapping(fromState: State, input: Input) -> State?
{
    switch (fromState, input) {
        case (.LoggedOut, .Login):
            return .LoggingIn
        case (.LoggingIn, .LoginOK):
            return .LoggedIn
        case (.LoggedIn, .Logout):
            return .LoggingOut
        case (.LoggingOut, .LogoutOK):
            return .LoggedOut

        // ForceLogout
        case (.LoggingIn, .ForceLogout), (.LoggedIn, .ForceLogout):
            return .LoggingOut

        default:
            return nil
    }
}

let automaton = Automaton<State, Input>(state: .LoggedOut, signal: signal, mapping: mapping)
```

can now be rewritten as:

``` swift
let canForceLogout: State -> Bool = { $0 == .LoggingIn || $0 == .LoggedIn }

let mappings: [Automaton<State, Input>.Mapping] = [
    .Login    | .LoggedOut => .LoggingIn,
    .LoginOK  | .LoggingIn => .LoggedIn,
    .Logout   | .LoggedIn => .LoggingOut,
    .LogoutOK | .LoggingOut => .LoggedOut,

    .ForceLogout | canForceLogout => .LoggingOut
]

let automaton = Automaton<State, Input>(state: .LoggedOut, signal: signal, mapping: concat(mappings))
```

Please see [AutomatonSpec.swift](https://github.com/inamiy/ReactiveAutomaton/blob/b80d8e82ace7801fb1189e588dd397a05baed26e/Tests/AutomatonSpec.swift) for more information.
