### PR TITLE
Add state-change-function support for syntax-sugar mapping

### DIFF
--- a/ReactiveAutomaton.xcodeproj/project.pbxproj
+++ b/ReactiveAutomaton.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1F24E04B1CDD0D760008028E /* ReactiveCocoa+SampleFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24E04A1CDD0D760008028E /* ReactiveCocoa+SampleFrom.swift */; };
 		1F24EB161CDD19240008028E /* ReactiveAutomaton.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FAEBCF51CDCEF510046EA72 /* ReactiveAutomaton.framework */; };
 		1F24EB3D1CDD197B0008028E /* MappingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24EB3B1CDD197B0008028E /* MappingSpec.swift */; };
+		1FA0AC441DE8AAC7007F01E0 /* StateFuncMappingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA0AC431DE8AAC7007F01E0 /* StateFuncMappingSpec.swift */; };
 		1FAEBD041CDCEF940046EA72 /* ReactiveAutomaton.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FAEBD021CDCEF940046EA72 /* ReactiveAutomaton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1FAEBD061CDCEFD50046EA72 /* Automaton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAEBD051CDCEFD50046EA72 /* Automaton.swift */; };
 		1FAEBD081CDCF04E0046EA72 /* Reply.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAEBD071CDCF04E0046EA72 /* Reply.swift */; };
@@ -53,6 +54,7 @@
 		1F24EB111CDD19240008028E /* ReactiveAutomatonTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveAutomatonTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F24EB3A1CDD197B0008028E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1F24EB3B1CDD197B0008028E /* MappingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappingSpec.swift; sourceTree = "<group>"; };
+		1FA0AC431DE8AAC7007F01E0 /* StateFuncMappingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateFuncMappingSpec.swift; sourceTree = "<group>"; };
 		1FAEBCF51CDCEF510046EA72 /* ReactiveAutomaton.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveAutomaton.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FAEBD011CDCEF940046EA72 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1FAEBD021CDCEF940046EA72 /* ReactiveAutomaton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReactiveAutomaton.h; sourceTree = "<group>"; };
@@ -134,8 +136,9 @@
 			children = (
 				487C0F271D00311E0071666D /* Fixtures */,
 				1F24EB3B1CDD197B0008028E /* MappingSpec.swift */,
-				487C0F4C1D003B2E0071666D /* AnyMappingSpec.swift */,
 				487C0F4A1D0032D80071666D /* NextMappingSpec.swift */,
+				487C0F4C1D003B2E0071666D /* AnyMappingSpec.swift */,
+				1FA0AC431DE8AAC7007F01E0 /* StateFuncMappingSpec.swift */,
 				48C03E751D4093610084B208 /* StrategyLatestSpec.swift */,
 				1F242AFE1D08766900647917 /* TerminatingSpec.swift */,
 				1F24EB3A1CDD197B0008028E /* Info.plist */,
@@ -327,6 +330,7 @@
 				1F24EB3D1CDD197B0008028E /* MappingSpec.swift in Sources */,
 				1F242B1E1D08770400647917 /* TerminatingSpec.swift in Sources */,
 				487C0F4B1D0032D80071666D /* NextMappingSpec.swift in Sources */,
+				1FA0AC441DE8AAC7007F01E0 /* StateFuncMappingSpec.swift in Sources */,
 				487C0F4D1D003B2E0071666D /* AnyMappingSpec.swift in Sources */,
 				487C0F291D00311E0071666D /* Fixtures.swift in Sources */,
 				48C03E951D4094270084B208 /* StrategyLatestSpec.swift in Sources */,

--- a/Sources/Mapping+Helper.swift
+++ b/Sources/Mapping+Helper.swift
@@ -57,6 +57,23 @@ public func | <State, Input: Equatable>(input: Input, transition: Transition<Sta
     return { $0 == input } | transition
 }
 
+public func | <State, Input>(inputFunc: @escaping (Input) -> Bool, transition: @escaping (State) -> State) -> Automaton<State, Input>.Mapping
+{
+    return { fromState, input in
+        if inputFunc(input) {
+            return transition(fromState)
+        }
+        else {
+            return nil
+        }
+    }
+}
+
+public func | <State, Input: Equatable>(input: Input, transition: @escaping (State) -> State) -> Automaton<State, Input>.Mapping
+{
+    return { $0 == input } | transition
+}
+
 // MARK: `|` (Automaton.NextMapping constructor)
 
 public func | <State, Input>(mapping: @escaping Automaton<State, Input>.Mapping, nextInputProducer: SignalProducer<Input, NoError>) -> Automaton<State, Input>.NextMapping

--- a/Tests/Fixtures/Fixtures.swift
+++ b/Tests/Fixtures/Fixtures.swift
@@ -10,6 +10,8 @@ import Result
 import ReactiveSwift
 import ReactiveAutomaton
 
+// MARK: AuthState/Input
+
 enum AuthState: String, CustomStringConvertible
 {
     case loggedOut
@@ -33,6 +35,20 @@ enum AuthInput: String, CustomStringConvertible
 
     var description: String { return self.rawValue }
 }
+
+// MARK: CountState/Input
+
+typealias CountState = Int
+
+enum CountInput: String, CustomStringConvertible
+{
+    case increment
+    case decrement
+
+    var description: String { return self.rawValue }
+}
+
+// MARK: MyState/Input
 
 enum MyState
 {

--- a/Tests/StateFuncMappingSpec.swift
+++ b/Tests/StateFuncMappingSpec.swift
@@ -1,0 +1,52 @@
+//
+//  StateFuncMappingSpec.swift
+//  ReactiveAutomaton
+//
+//  Created by Yasuhiro Inami on 2016-11-26.
+//  Copyright © 2016 Yasuhiro Inami. All rights reserved.
+//
+
+import Result
+import ReactiveSwift
+import ReactiveAutomaton
+import Quick
+import Nimble
+
+/// Tests for state-change function mapping.
+class StateFuncMappingSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("State-change function mapping") {
+
+            typealias Automaton = ReactiveAutomaton.Automaton<CountState, CountInput>
+            typealias NextMapping = Automaton.NextMapping
+
+            let (signal, observer) = Signal<CountInput, NoError>.pipe()
+            var automaton: Automaton?
+
+            beforeEach {
+                let mappings: [Automaton.NextMapping] = [
+                    .increment | { $0 + 1 } | .empty,
+                    .decrement | { $0 - 1 } | .empty,
+                ]
+
+                // strategy = `.merge`
+                automaton = Automaton(state: 0, input: signal, mapping: reduce(mappings), strategy: .merge)
+            }
+
+            it("`.increment` and `.decrement` succeed") {
+                expect(automaton?.state.value) == 0
+                observer.send(value: .increment)
+                expect(automaton?.state.value) == 1
+                observer.send(value: .increment)
+                expect(automaton?.state.value) == 2
+                observer.send(value: .decrement)
+                expect(automaton?.state.value) == 1
+                observer.send(value: .decrement)
+                expect(automaton?.state.value) == 0
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
This PR will support state-changing function as follows:

```swift
let mappings: [Automaton.NextMapping] = [
  /*   Input   |    State   |  Effect   */
  /* -----------------------------------*/
    .increment | { $0 + 1 } | .empty,
    .decrement | { $0 - 1 } | .empty,
]
```