### PR TITLE
Add `Effect.until` for cancellation

### DIFF
--- a/Sources/Mapping+Helper.swift
+++ b/Sources/Mapping+Helper.swift
@@ -89,7 +89,7 @@ public func | <State, Input>(
 
 public func | <State, Input, Queue>(
     mapping: @escaping Automaton<State, Input>.Mapping,
-    effect: Effect<Input, Queue>?
+    effect: Effect<Input, State, Queue>?
     ) -> Automaton<State, Input>.EffectMapping<Queue>
 {
     return { fromState, input in

--- a/Tests/ReactiveAutomatonTests/EffectCancellationSpec.swift
+++ b/Tests/ReactiveAutomatonTests/EffectCancellationSpec.swift
@@ -7,19 +7,17 @@ class EffectCancellationSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<State, Input>
-        typealias EffectMapping = Automaton.EffectMapping<Never>
-
-        let (signal, observer) = Signal<Input, Never>.pipe()
-        var automaton: Automaton?
-        var lastReply: Reply<State, Input>?
-        var testScheduler: TestScheduler!
-        var isEffectDetected: Bool = false
-
-        // WARNING:
-        // Handling `Lifetime` is actually a side-effect that should not run inside `EffectMapping`.
-        // So, this test is actually not a good example of handling cancellation.
         describe("Cancellation using Lifetime") {
+
+            typealias State = _State<Lifetime.Token>
+            typealias Automaton = ReactiveAutomaton.Automaton<State, Input>
+            typealias EffectMapping = Automaton.EffectMapping<Never>
+
+            let (signal, observer) = Signal<Input, Never>.pipe()
+            var automaton: Automaton?
+            var lastReply: Reply<State, Input>?
+            var testScheduler: TestScheduler!
+            var isEffectDetected: Bool = false
 
             beforeEach {
                 testScheduler = TestScheduler()
@@ -33,9 +31,6 @@ class EffectCancellationSpec: QuickSpec
                 let mapping: EffectMapping = { fromState, input in
                     switch (fromState.status, input) {
                     case (.idle, .userAction(.request)):
-                        // WARNING:
-                        // Handling `Lifetime` is actually a side-effect that should not run inside `EffectMapping`.
-                        // So, this test is actually not a good example of handling cancellation.
                         let (lifetime, token) = Lifetime.make()
                         let toState = fromState.with {
                             $0.status = .requesting(token)
@@ -46,6 +41,113 @@ class EffectCancellationSpec: QuickSpec
                                 isEffectDetected = true
                             })
                         return (toState, Effect(effect))
+
+                    case (.requesting, .userAction(.cancel)):
+                        let toState = fromState.with {
+                            $0.status = .idle
+                        }
+                        return (toState, nil)
+
+                    case (.requesting, .requestOK):
+                        let toState = fromState.with {
+                            $0.status = .idle
+                        }
+                        return (toState, nil)
+
+                    default:
+                        return nil
+                    }
+                }
+
+                automaton = Automaton(state: State(), inputs: signal, mapping: mapping)
+
+                _ = automaton?.replies.observeValues { reply in
+                    lastReply = reply
+                }
+
+                lastReply = nil
+            }
+
+            it("request success") {
+                expect(automaton?.state.value.status) == .idle
+                expect(lastReply).to(beNil())
+
+                observer.send(value: .userAction(.request))
+
+                expect(lastReply?.input) == .userAction(.request)
+                expect(lastReply?.fromState.status) == .idle
+                expect(lastReply?.toState?.status.requesting).toNot(beNil())
+                expect(automaton?.state.value.status.requesting).toNot(beNil())
+
+                // `loginOKProducer` will automatically send `.loginOK`
+                testScheduler.advance(by: .seconds(2))
+
+                expect(lastReply?.input) == .requestOK
+                expect(lastReply?.fromState.status.requesting).toNot(beNil())
+                expect(lastReply?.toState?.status) == .idle
+                expect(automaton?.state.value.status) == .idle
+                expect(isEffectDetected) == true
+            }
+
+            it("request cancelled") {
+                expect(automaton?.state.value.status) == .idle
+                expect(lastReply).to(beNil())
+
+                observer.send(value: .userAction(.request))
+
+                expect(lastReply?.input) == .userAction(.request)
+                expect(lastReply?.fromState.status) == .idle
+                expect(lastReply?.toState?.status.requesting).toNot(beNil())
+                expect(automaton?.state.value.status.requesting).toNot(beNil())
+
+                // `loginOKProducer` will automatically send `.loginOK`
+                observer.send(value: .userAction(.cancel))
+
+                expect(lastReply?.input) == .userAction(.cancel)
+                expect(lastReply?.fromState.status.requesting).toNot(beNil())
+                expect(lastReply?.toState?.status) == .idle
+                expect(automaton?.state.value.status) == .idle
+
+                lastReply = nil // clear `lastReply` to not retain `Lifetime.Token`
+                testScheduler.advance(by: .seconds(2))
+
+                expect(isEffectDetected) == false
+            }
+
+        }
+
+        describe("Cancellation using Effect.until") {
+
+            typealias State = _State<_Void>
+            typealias Automaton = ReactiveAutomaton.Automaton<State, Input>
+            typealias EffectMapping = Automaton.EffectMapping<Never>
+
+            let (signal, observer) = Signal<Input, Never>.pipe()
+            var automaton: Automaton?
+            var lastReply: Reply<State, Input>?
+            var testScheduler: TestScheduler!
+            var isEffectDetected: Bool = false
+
+            beforeEach {
+                testScheduler = TestScheduler()
+                isEffectDetected = false
+
+                /// Sends `.loginOK` after delay, simulating async work during `.loggingIn`.
+                let requestOKProducer =
+                    SignalProducer<Input, Never>(value: .requestOK)
+                        .delay(1, on: testScheduler)
+
+                let mapping: EffectMapping = { fromState, input in
+                    switch (fromState.status, input) {
+                    case (.idle, .userAction(.request)):
+                        let toState = fromState.with {
+                            $0.status = .requesting(_Void())
+                        }
+                        let effect = requestOKProducer
+                            .on(value: { _ in
+                                isEffectDetected = true
+                            })
+                        return (toState, Effect(effect, until: .userAction(.cancel)))
 
                     case (.requesting, .userAction(.cancel)):
                         let toState = fromState.with {
@@ -138,18 +240,21 @@ private enum Input: Equatable
     }
 }
 
-private struct State: With, Equatable
+private struct _State<Requesting>: With, Equatable
+    where Requesting: Equatable
 {
     var status: Status = .idle
 
     enum Status: Equatable {
         case idle
-        case requesting(Lifetime.Token)
+        case requesting(Requesting)
 
-        var requesting: Lifetime.Token?
+        var requesting: Requesting?
         {
             guard case let .requesting(value) = self else { return nil }
             return value
         }
     }
 }
+
+private struct _Void: Equatable {}


### PR DESCRIPTION
This PR improves #12 Effect Handling by adding `Effect.until` for easy cancellation.

**Note:** `Effect.until` will be triggered regardless of state-transition success or failure.