### PR TITLE
Reverse input-state param order

### DIFF
--- a/Sources/Automaton+Feedback.swift
+++ b/Sources/Automaton+Feedback.swift
@@ -13,7 +13,7 @@ extension Automaton
         state initialState: State,
         inputs inputSignal: Signal<Input, Never>,
         mapping: @escaping Mapping,
-        feedback: Feedback<Reply<State, Input>.Success, Input>
+        feedback: Feedback<Reply<Input, State>.Success, Input>
         )
     {
         self.init(
@@ -22,11 +22,11 @@ extension Automaton
             makeSignals: { from -> MakeSignals in
                 let mapped = from
                     .map { input, fromState in
-                        return (input, fromState, mapping(fromState, input))
+                        return (input, fromState, mapping(input, fromState))
                     }
 
                 let replies = mapped
-                    .map { input, fromState, mapped -> Reply<State, Input> in
+                    .map { input, fromState, mapped -> Reply<Input, State> in
                         if let toState = mapped {
                             return .success((input, fromState, toState))
                         }

--- a/Sources/Reply.swift
+++ b/Sources/Reply.swift
@@ -1,5 +1,5 @@
 /// `Automaton`'s reply to state transition.
-public enum Reply<State, Input>
+public enum Reply<Input, State>
 {
     /// Transition success, i.e. `(input, fromState, toState)`.
     case success(Success)

--- a/Tests/ReactiveAutomatonTests/AnyMappingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/AnyMappingSpec.swift
@@ -8,11 +8,11 @@ class AnyMappingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<MyState, MyInput>
+        typealias Automaton = ReactiveAutomaton.Automaton<MyInput, MyState>
 
         let (signal, observer) = Signal<MyInput, Never>.pipe()
         var automaton: Automaton?
-        var lastReply: Reply<MyState, MyInput>?
+        var lastReply: Reply<MyInput, MyState>?
 
         describe("`anyState`/`anyInput` mapping") {
 

--- a/Tests/ReactiveAutomatonTests/EffectCancellationSpec.swift
+++ b/Tests/ReactiveAutomatonTests/EffectCancellationSpec.swift
@@ -10,12 +10,12 @@ class EffectCancellationSpec: QuickSpec
         describe("Cancellation using Lifetime") {
 
             typealias State = _State<Lifetime.Token>
-            typealias Automaton = ReactiveAutomaton.Automaton<State, Input>
+            typealias Automaton = ReactiveAutomaton.Automaton<Input, State>
             typealias EffectMapping = Automaton.EffectMapping<Never>
 
             let (signal, observer) = Signal<Input, Never>.pipe()
             var automaton: Automaton?
-            var lastReply: Reply<State, Input>?
+            var lastReply: Reply<Input, State>?
             var testScheduler: TestScheduler!
             var isEffectDetected: Bool = false
 
@@ -28,7 +28,7 @@ class EffectCancellationSpec: QuickSpec
                     SignalProducer<Input, Never>(value: .requestOK)
                         .delay(1, on: testScheduler)
 
-                let mapping: EffectMapping = { fromState, input in
+                let mapping: EffectMapping = { input, fromState in
                     switch (fromState.status, input) {
                     case (.idle, .userAction(.request)):
                         let (lifetime, token) = Lifetime.make()
@@ -119,12 +119,12 @@ class EffectCancellationSpec: QuickSpec
         describe("Cancellation using Effect.until") {
 
             typealias State = _State<_Void>
-            typealias Automaton = ReactiveAutomaton.Automaton<State, Input>
+            typealias Automaton = ReactiveAutomaton.Automaton<Input, State>
             typealias EffectMapping = Automaton.EffectMapping<Never>
 
             let (signal, observer) = Signal<Input, Never>.pipe()
             var automaton: Automaton?
-            var lastReply: Reply<State, Input>?
+            var lastReply: Reply<Input, State>?
             var testScheduler: TestScheduler!
             var isEffectDetected: Bool = false
 
@@ -137,7 +137,7 @@ class EffectCancellationSpec: QuickSpec
                     SignalProducer<Input, Never>(value: .requestOK)
                         .delay(1, on: testScheduler)
 
-                let mapping: EffectMapping = { fromState, input in
+                let mapping: EffectMapping = { input, fromState in
                     switch (fromState.status, input) {
                     case (.idle, .userAction(.request)):
                         let toState = fromState.with {

--- a/Tests/ReactiveAutomatonTests/EffectMappingLatestSpec.swift
+++ b/Tests/ReactiveAutomatonTests/EffectMappingLatestSpec.swift
@@ -8,12 +8,12 @@ class EffectMappingLatestSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<AuthState, AuthInput>
+        typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
         typealias EffectMapping = Automaton.EffectMapping<Queue>
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
 
         describe("strategy = `.latest`") {
 

--- a/Tests/ReactiveAutomatonTests/EffectMappingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/EffectMappingSpec.swift
@@ -3,18 +3,18 @@ import ReactiveAutomaton
 import Quick
 import Nimble
 
-/// Tests for `(State, Input) -> (State, Output)?` mapping
+/// Tests for `(Input, State) -> (State, Output)?` mapping
 /// where `Output = SignalProducer<Input, Never>`.
 class EffectMappingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<AuthState, AuthInput>
+        typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
         typealias EffectMapping = Automaton.EffectMapping<Never>
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
         var testScheduler: TestScheduler!
 
         describe("Syntax-sugar EffectMapping") {
@@ -100,15 +100,15 @@ class EffectMappingSpec: QuickSpec
                     SignalProducer<AuthInput, Never>(value: .logoutOK)
                         .delay(1, on: testScheduler)
 
-                let mapping: EffectMapping = { fromState, input in
-                    switch (fromState, input) {
-                        case (.loggedOut, .login):
+                let mapping: EffectMapping = { input, fromState in
+                    switch (input, fromState) {
+                        case (.login, .loggedOut):
                             return (.loggingIn, .init(loginOKProducer))
-                        case (.loggingIn, .loginOK):
+                        case (.loginOK, .loggingIn):
                             return (.loggedIn, nil)
-                        case (.loggedIn, .logout):
+                        case (.logout, .loggedIn):
                             return (.loggingOut, .init(logoutOKProducer))
-                        case (.loggingOut, .logoutOK):
+                        case (.logoutOK, .loggingOut):
                             return (.loggedOut, nil)
                         default:
                             return nil

--- a/Tests/ReactiveAutomatonTests/FeedbackSpec.swift
+++ b/Tests/ReactiveAutomatonTests/FeedbackSpec.swift
@@ -7,13 +7,13 @@ class FeedbackSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<AuthState, AuthInput>
+        typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
         typealias Mapping = Automaton.Mapping
-        typealias Feedback = ReactiveAutomaton.Feedback<Reply<AuthState, AuthInput>.Success, AuthInput>
+        typealias Feedback = ReactiveAutomaton.Feedback<Reply<AuthInput, AuthState>.Success, AuthInput>
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
         var testScheduler: TestScheduler!
 
         describe("Feedback") {

--- a/Tests/ReactiveAutomatonTests/InitialEffectSpec.swift
+++ b/Tests/ReactiveAutomatonTests/InitialEffectSpec.swift
@@ -7,12 +7,12 @@ class InitialEffectSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<AuthState, AuthInput>
+        typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
         typealias EffectMapping = Automaton.EffectMapping<Never>
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
         var testScheduler: TestScheduler!
 
         describe("InitialEffect") {

--- a/Tests/ReactiveAutomatonTests/MappingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/MappingSpec.swift
@@ -3,17 +3,17 @@ import ReactiveAutomaton
 import Quick
 import Nimble
 
-/// Tests for `(State, Input) -> State?` mapping.
+/// Tests for `(Input, State) -> State?` mapping.
 class MappingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<AuthState, AuthInput>
+        typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
         typealias Mapping = Automaton.Mapping
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
 
         describe("Syntax-sugar Mapping") {
 
@@ -119,19 +119,19 @@ class MappingSpec: QuickSpec
         describe("Func-based Mapping") {
 
             beforeEach {
-                let mapping: Mapping = { fromState, input in
-                    switch (fromState, input) {
-                        case (.loggedOut, .login):
+                let mapping: Mapping = { input, fromState in
+                    switch (input, fromState) {
+                        case (.login, .loggedOut):
                             return .loggingIn
-                        case (.loggingIn, .loginOK):
+                        case (.loginOK, .loggingIn):
                             return .loggedIn
-                        case (.loggedIn, .logout):
+                        case (.logout, .loggedIn):
                             return .loggingOut
-                        case (.loggingOut, .logoutOK):
+                        case (.logoutOK, .loggingOut):
                             return .loggedOut
 
                         // ForceLogout
-                        case (.loggingIn, .forceLogout), (.loggedIn, .forceLogout):
+                        case (.forceLogout, .loggingIn), (.forceLogout, .loggedIn):
                             return .loggingOut
 
                         default:

--- a/Tests/ReactiveAutomatonTests/StateFuncMappingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/StateFuncMappingSpec.swift
@@ -10,7 +10,7 @@ class StateFuncMappingSpec: QuickSpec
     {
         describe("State-change function mapping") {
 
-            typealias Automaton = ReactiveAutomaton.Automaton<CountState, CountInput>
+            typealias Automaton = ReactiveAutomaton.Automaton<CountInput, CountState>
             typealias EffectMapping = Automaton.EffectMapping<Never>
 
             let (signal, observer) = Signal<CountInput, Never>.pipe()

--- a/Tests/ReactiveAutomatonTests/TerminatingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/TerminatingSpec.swift
@@ -7,13 +7,13 @@ class TerminatingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Automaton = ReactiveAutomaton.Automaton<MyState, MyInput>
+        typealias Automaton = ReactiveAutomaton.Automaton<MyInput, MyState>
         typealias Mapping = Automaton.Mapping
         typealias EffectMapping = Automaton.EffectMapping<Never>
 
         var automaton: Automaton?
-        var lastReply: Reply<MyState, MyInput>?
-        var lastRepliesEvent: Signal<Reply<MyState, MyInput>, Never>.Event?
+        var lastReply: Reply<MyInput, MyState>?
+        var lastRepliesEvent: Signal<Reply<MyInput, MyState>, Never>.Event?
 
         /// Flag for internal effect `sendInput1And2AfterDelay` disposed.
         var effectDisposed: Bool?


### PR DESCRIPTION
This PR reorders the type-param order of `State` and `Input`, e.g.

```diff
-public typealias Mapping = (State, Input) -> State?
+public typealias Mapping = (Input, State) -> State?
```

Main reasons are:

- Elm uses `update : Input -> State -> (State, Cmd<Input>)` signature
- This can be interpreted using State monad, i.e. `Input -> StateMonad<State, Cmd<Input>>`