### PR TITLE
Replace `Effect.until` with `EffectID`-based `Effect.cancel`

### DIFF
--- a/Sources/Effect.swift
+++ b/Sources/Effect.swift
@@ -2,34 +2,58 @@ import ReactiveSwift
 
 /// Managed side-effect that enqueues `producer` on `EffectQueue`
 /// to perform arbitrary `Queue.flattenStrategy`.
-public struct Effect<Input, State, Queue> where Queue: EffectQueueProtocol
+///
+/// This type also handles effect cancellation via `cancel`.
+public struct Effect<Input, Queue, ID>
+    where Queue: EffectQueueProtocol, ID: Equatable
 {
-    /// "Cold" stream that runs side-effect and sends next `Input`.
-    public let producer: SignalProducer<Input, Never>
+    internal let kind: Kind
 
-    /// Effect queue that associates with `producer` to perform various `flattenStrategy`s.
-    internal let queue: EffectQueue<Queue>
+    internal init(kind: Kind)
+    {
+        self.kind = kind
+    }
 
-    /// `(input, fromState)` predicate for running `producer` cancellation.
-    /// - Note: Cancellation will be triggered regardless of state-transition success or failure.
-    internal let until: (Input, State) -> Bool
-
+    /// Managed side-effect that enqueues `producer` on `EffectQueue`
+    /// to perform arbitrary `Queue.flattenStrategy`.
+    ///
     /// - Parameters:
+    ///   - producer: "Cold" stream that runs side-effect and sends next `Input`.
     ///   - queue: Uses custom queue, or set `nil` as default queue to use `merge` strategy.
-    ///   - until: `(input, fromState)` predicate for running `producer` cancellation.
+    ///   - id: Effect identifier for cancelling running `producer`.
     public init(
         _ producer: SignalProducer<Input, Never>,
         queue: Queue? = nil,
-        until: @escaping (Input, State) -> Bool = { _, _ in false }
+        id: ID? = nil
         )
     {
-        self.producer = producer
-        self.queue = queue.map(EffectQueue.custom) ?? .default
-        self.until = until
+        self.init(kind: .producer(
+            Producer(
+                producer: producer,
+                queue: queue.map(EffectQueue.custom) ?? .default,
+                id: id
+            )
+        ))
+    }
+
+    /// Cancels running `producer` by specifying `identifiers`.
+    public static func cancel(
+        _ identifiers: @escaping (ID) -> Bool
+        ) -> Effect<Input, Queue, ID>
+    {
+        return Effect(kind: .cancel(identifiers))
+    }
+
+    /// Cancels running `producer` by specifying `identifier`.
+    public static func cancel(
+        _ identifier: ID
+        ) -> Effect<Input, Queue, ID>
+    {
+        return Effect(kind: .cancel { $0 == identifier })
     }
 
     /// Empty side-effect.
-    public static var none: Effect<Input, State, Queue>
+    public static var none: Effect<Input, Queue, ID>
     {
         return Effect(.empty)
     }
@@ -43,18 +67,40 @@ extension Effect: ExpressibleByNilLiteral
     }
 }
 
-extension Effect where Input: Equatable
+extension Effect
 {
-    public init(
-        _ producer: SignalProducer<Input, Never>,
-        queue: Queue? = nil,
-        until input: Input
-        )
+    internal var producer: Producer?
     {
-        self.init(
-            producer,
-            queue: queue,
-            until: { i, _ in i == input }
-        )
+        guard case let .producer(value) = self.kind else { return nil }
+        return value
+    }
+
+    internal var cancel: ((ID) -> Bool)?
+    {
+        guard case let .cancel(value) = self.kind else { return nil }
+        return value
+    }
+}
+
+// MARK: - Inner Types
+
+extension Effect
+{
+    internal enum Kind
+    {
+        case producer(Producer)
+        case cancel((ID) -> Bool)
+    }
+
+    internal struct Producer
+    {
+        /// "Cold" stream that runs side-effect and sends next `Input`.
+        internal let producer: SignalProducer<Input, Never>
+
+        /// Effect queue that associates with `producer` to perform various `flattenStrategy`s.
+        internal let queue: EffectQueue<Queue>
+
+        /// Effect identifier for cancelling running `producer`.
+        internal let id: ID?
     }
 }

--- a/Sources/Mapping+Helper.swift
+++ b/Sources/Mapping+Helper.swift
@@ -79,18 +79,18 @@ public func | <Input: Equatable, State>(
 
 // MARK: `|` (Automaton.EffectMapping constructor)
 
-public func | <Input, State, Queue>(
+public func | <Input, State, Queue, EffectID>(
     mapping: @escaping Automaton<Input, State>.Mapping,
     effect: SignalProducer<Input, Never>
-    ) -> Automaton<Input, State>.EffectMapping<Queue>
+    ) -> Automaton<Input, State>.EffectMapping<Queue, EffectID>
 {
     return mapping | Effect(effect)
 }
 
-public func | <Input, State, Queue>(
+public func | <Input, State, Queue, EffectID>(
     mapping: @escaping Automaton<Input, State>.Mapping,
-    effect: Effect<Input, State, Queue>
-    ) -> Automaton<Input, State>.EffectMapping<Queue>
+    effect: Effect<Input, Queue, EffectID>
+    ) -> Automaton<Input, State>.EffectMapping<Queue, EffectID>
 {
     return { input, fromState in
         if let toState = mapping(input, fromState) {
@@ -128,9 +128,9 @@ public func reduce<Input, State, Mappings: Sequence>(_ mappings: Mappings)
 }
 
 /// Folds multiple `Automaton.EffectMapping`s into one (preceding mapping has higher priority).
-public func reduce<Input, State, Mappings: Sequence, Queue>(_ mappings: Mappings)
-    -> Automaton<Input, State>.EffectMapping<Queue>
-    where Mappings.Iterator.Element == Automaton<Input, State>.EffectMapping<Queue>
+public func reduce<Input, State, Mappings: Sequence, Queue, EffectID>(_ mappings: Mappings)
+    -> Automaton<Input, State>.EffectMapping<Queue, EffectID>
+    where Mappings.Iterator.Element == Automaton<Input, State>.EffectMapping<Queue, EffectID>
 {
     return { input, fromState in
         for mapping in mappings {
@@ -145,8 +145,8 @@ public func reduce<Input, State, Mappings: Sequence, Queue>(_ mappings: Mappings
 // MARK: - Mapping conversion
 
 /// Converts `Automaton.Mapping` to `Automaton.EffectMapping`.
-public func toEffectMapping<Input, State, Queue>(_ mapping: @escaping Automaton<Input, State>.Mapping)
-    -> Automaton<Input, State>.EffectMapping<Queue>
+public func toEffectMapping<Input, State, Queue, EffectID>(_ mapping: @escaping Automaton<Input, State>.Mapping)
+    -> Automaton<Input, State>.EffectMapping<Queue, EffectID>
 {
     return { input, state in
         return mapping(input, state).map { ($0, nil) }
@@ -154,8 +154,8 @@ public func toEffectMapping<Input, State, Queue>(_ mapping: @escaping Automaton<
 }
 
 /// Converts `Automaton.EffectMapping` to `Automaton.Mapping`, discarding effects.
-public func toMapping<Input, State, Queue>(
-    _ effectMapping: @escaping Automaton<Input, State>.EffectMapping<Queue>
+public func toMapping<Input, State, Queue, EffectID>(
+    _ effectMapping: @escaping Automaton<Input, State>.EffectMapping<Queue, EffectID>
     ) -> Automaton<Input, State>.Mapping
 {
     return { input, state in

--- a/Tests/ReactiveAutomatonTests/EffectMappingLatestSpec.swift
+++ b/Tests/ReactiveAutomatonTests/EffectMappingLatestSpec.swift
@@ -9,7 +9,7 @@ class EffectMappingLatestSpec: QuickSpec
     override func spec()
     {
         typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
-        typealias EffectMapping = Automaton.EffectMapping<Queue>
+        typealias EffectMapping = Automaton.EffectMapping<Queue, Never>
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?

--- a/Tests/ReactiveAutomatonTests/EffectMappingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/EffectMappingSpec.swift
@@ -10,7 +10,7 @@ class EffectMappingSpec: QuickSpec
     override func spec()
     {
         typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
-        typealias EffectMapping = Automaton.EffectMapping<Never>
+        typealias EffectMapping = Automaton.EffectMapping<Never, Never>
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?

--- a/Tests/ReactiveAutomatonTests/InitialEffectSpec.swift
+++ b/Tests/ReactiveAutomatonTests/InitialEffectSpec.swift
@@ -8,7 +8,7 @@ class InitialEffectSpec: QuickSpec
     override func spec()
     {
         typealias Automaton = ReactiveAutomaton.Automaton<AuthInput, AuthState>
-        typealias EffectMapping = Automaton.EffectMapping<Never>
+        typealias EffectMapping = Automaton.EffectMapping<Never, Never>
 
         let (signal, observer) = Signal<AuthInput, Never>.pipe()
         var automaton: Automaton?

--- a/Tests/ReactiveAutomatonTests/StateFuncMappingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/StateFuncMappingSpec.swift
@@ -11,7 +11,7 @@ class StateFuncMappingSpec: QuickSpec
         describe("State-change function mapping") {
 
             typealias Automaton = ReactiveAutomaton.Automaton<CountInput, CountState>
-            typealias EffectMapping = Automaton.EffectMapping<Never>
+            typealias EffectMapping = Automaton.EffectMapping<Never, Never>
 
             let (signal, observer) = Signal<CountInput, Never>.pipe()
             var automaton: Automaton?

--- a/Tests/ReactiveAutomatonTests/TerminatingSpec.swift
+++ b/Tests/ReactiveAutomatonTests/TerminatingSpec.swift
@@ -9,7 +9,7 @@ class TerminatingSpec: QuickSpec
     {
         typealias Automaton = ReactiveAutomaton.Automaton<MyInput, MyState>
         typealias Mapping = Automaton.Mapping
-        typealias EffectMapping = Automaton.EffectMapping<Never>
+        typealias EffectMapping = Automaton.EffectMapping<Never, Never>
 
         var automaton: Automaton?
         var lastReply: Reply<MyInput, MyState>?


### PR DESCRIPTION
This PR refactors #13 by **removing `Effect.until` and instead introducing effect-identifier-based `Effect.cancel`** for more precise cancellation.

The architecture is similar to [Elm.Http](https://package.elm-lang.org/packages/elm/http/latest/Http) using `tracker` as effect identifier:

```elm
-- The `tracker` lets you cancel and track requests.
request :
    { method : String
    , headers : List Header
    , url : String
    , body : Body
    , expect : Expect msg
    , timeout : Maybe Float
    , tracker : Maybe String
    }
    -> Cmd msg

cancel : String -> Cmd msg
```

## Motivation

Effect identification becomes more important when same producers are generated by `EffectMapping` with same `(input, fromState)` pair given, but still want to **distinguish them to only cancel a particular effect**.

For example:

```swift
let mapping: EffectMapping = { input, state in
    switch input {
        case .request: return (state, Effect(someProducer, until: .cancel)
        case .cancel: return state
    }
}
let automaton = Automaton(..., inputs: inputs, mapping: mapping)
inputs.input.send(.request)
inputs.input.send(.request)
inputs.input.send(.request)
// NOTE: 3 same effects are produced (with `.merge` strategy)

inputs.input.send(.cancel) // Q. How to cancel only 2nd request?
```

This kind of async request & cancellation scenario might happen, and to precisely manage effect to identify 1st, 2nd, 3rd, **adding an effect-identifier is necessary to distinguish them**.

While `Effect(..., until:)` can still implement its identifier inside `until` closure, it is simpler to just change to `Effect(..., id: EffectID)`.
Also, `until: (Input, FromState) -> Bool` is actually a part of mapping function that should rather go inside `EffectMapping`, so that we don't have to bother with the following #13 contradiction: 

```
**Note:** `Effect.until` will be triggered regardless of state-transition success or failure.
```

where effect-cancellation is in reality **also a part of effect that should only be invoked when state-transition succeeds**.

By moving `until` functionality inside `EffectMapping` and calling `Effect.cancel(effectID)` for state-transition success only, we can solve this contradiction.